### PR TITLE
Added pluralize to table names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,8 @@
 {
-    "requires": true,
+    "name": "md-database",
+    "version": "1.0.1",
     "lockfileVersion": 1,
+    "requires": true,
     "dependencies": {
         "@types/node": {
             "version": "16.7.5",
@@ -8,11 +10,21 @@
             "integrity": "sha512-E7SpxDXoHEpmZ9C1gSqwadhE6zPRtf3g0gJy9Y51DsImnR5TcDs3QEiV/3Q7zOM8LWaZp5Gph71NK6ElVMG1IQ==",
             "dev": true
         },
+        "@types/pluralize": {
+            "version": "0.0.29",
+            "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.29.tgz",
+            "integrity": "sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==",
+            "dev": true
+        },
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "pluralize": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+            "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
         }
-    },
-    "version": "1.0.1"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
         "node-clean": "del package-lock.json && rmdir /S /Q node_modules"
     },
     "dependencies": {
-        "is-number": "^7.0.0"
+        "is-number": "^7.0.0",
+        "pluralize": "^8.0.0"
     },
     "devDependencies": {
-        "@types/node": "^16.7.5"
+        "@types/node": "^16.7.5",
+        "@types/pluralize": "0.0.29"
     },
     "name": "md-database",
     "description": "Middleware for producing SQL queries from Markdown",

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import { readFile, writeFile } from "fs/promises";
 import * as Generic from "./interfaces/Generic";
 import { ucwords } from "./lib/string";
+import { plural } from "pluralize";
 
 const isNumber = require("is-number");
 
@@ -361,9 +362,9 @@ export class MDDatabase {
                         type: "TEXT"
                     });
                     keys.push(
-                        `FOREIGN KEY (${columns[columns.length - 1].field}) REFERENCES \`${escape(
-                            marker_type
-                        )}s\` (\`${escape(marker_type)}_uuid\`)`
+                        `FOREIGN KEY (${columns[columns.length - 1].field}) REFERENCES \`${plural(
+                            escape(marker_type)
+                        )}\` (\`${escape(marker_type)}_uuid\`)`
                     );
                 } else {
                     let format = getType(type_to_table[type].raw[property], true);
@@ -393,12 +394,14 @@ export class MDDatabase {
                 keys.splice(
                     1,
                     0,
-                    `FOREIGN KEY (\`${type}_${parent_type_escape}_uuid\`) REFERENCES \`${parent_type_escape}s\` (\`${parent_type_escape}_uuid\`)`
+                    `FOREIGN KEY (\`${type}_${parent_type_escape}_uuid\`) REFERENCES \`${plural(
+                        parent_type_escape
+                    )}\` (\`${parent_type_escape}_uuid\`)`
                 );
             }
 
             schema.push(
-                `CREATE TABLE IF NOT EXISTS \`${type}s\` (
+                `CREATE TABLE IF NOT EXISTS \`${plural(type)}\` (
     ${columns
         .map(column => {
             return `${column.field} ${column.type}`;
@@ -411,7 +414,7 @@ export class MDDatabase {
 
             if (type_to_table[type].insert.length) {
                 inserts.push(
-                    `INSERT INTO \`${type}s\`
+                    `INSERT INTO \`${plural(type)}\`
     (${columns.map(column => column.field).join(", ")}) VALUES
     ${type_to_table[type].insert
         .map(record => {


### PR DESCRIPTION
Tables should correctly be named for the plural form of their type.

In the future I could add singular() to object.type at definition to make this smoother if problems raise.

Fixes #10 