### PR TITLE
Fix for Typescript properties being incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ main();
 
 -   Forename: John
 -   Surname: Watson
+
 ```
 
 ### Output: Markdown
@@ -151,6 +152,7 @@ main();
 
 -   Forename: John
 -   Surname: Watson
+
 ```
 
 ### Output: JSON
@@ -218,12 +220,12 @@ CREATE TABLE IF NOT EXISTS `occupants` (
 
 INSERT INTO `buildings`
     (`building_uuid`, `building_house_number`, `building_street`, `building_city`, `building_postcode`) VALUES
-    ("483140d6-3036-48bf-83e8-fb3435c1ca38", "221b", "Baker Street", "London", "NW1 6XE");
+    ("87b58a10-f863-404c-aab3-7fa6d55967d0", "221b", "Baker Street", "London", "NW1 6XE");
 
 INSERT INTO `occupants`
     (`occupant_building_uuid`, `occupant_uuid`, `occupant_forename`, `occupant_surname`) VALUES
-    ("483140d6-3036-48bf-83e8-fb3435c1ca38", "86d33184-6690-4af2-9b37-d03acc103965", "Sherlock", "Holmes"),
-    ("483140d6-3036-48bf-83e8-fb3435c1ca38", "ccfc9832-7ec1-4443-91c2-75a4251c58a4", "John", "Watson");
+    ("87b58a10-f863-404c-aab3-7fa6d55967d0", "b064eff0-276c-405b-ae01-48ed60b27f79", "Sherlock", "Holmes"),
+    ("87b58a10-f863-404c-aab3-7fa6d55967d0", "2618c3ca-1183-44e8-805e-95e5957be3b7", "John", "Watson");
 ```
 
 ### Output: TS
@@ -231,7 +233,7 @@ INSERT INTO `occupants`
 ```ts
 class MDDatabaseClass<Properties> {
     data: Properties;
-
+    
     constructor(properties: Properties) {
         this.data = properties;
     }
@@ -251,12 +253,13 @@ export namespace Building {
 
 export namespace Occupant {
     export interface Object {
-        occupant_uuid: string;
         occupant_building_uuid: string;
+        occupant_uuid: string;
         occupant_forename?: string;
         occupant_surname?: string;
     }
 
     export class Instance extends MDDatabaseClass<Object> {}
 }
+
 ```


### PR DESCRIPTION
Big restructure to allow toSQL and toTS to use the same fundamental base, named `buildMaps()` which generates and returns three sets of structured data:
- `type_to_table`, used to document everything about a given type: columns, keys, raw values, insert records, parent type
- `name_to_recrd`, used to match data references `{name}` to records
- `flat`, flattened array of Record objects (same as flatten(this.data)

Minor change:

- TypeScript properties/interfaces now match table order (parent key, foreign keys, primary key, fields)

Main change:

- TypeScript properties now exactly match table names, using the same internal code, resolves #15 