### PR TITLE
Added options for toSQL

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -294,66 +294,75 @@ export class MDDatabase {
     /* #endregion */
 
     /* #region Management Functions */
-    getOptions(options: Partial<MDDatabaseOptions> = {}): MDDatabaseOptions {
-        let final_options = Object.assign(
+    getOptions(in_options: number | Partial<MDDatabaseOptions> = {}): MDDatabaseOptions {
+        /**
+         * backwards compatability for unique_depth argument
+         */
+        if (typeof in_options === "number") {
+            in_options = {
+                unique_depth: in_options
+            };
+        }
+
+        let options = Object.assign(
             {
                 unique_depth: 0,
                 type: {}
             },
-            options || {}
+            in_options || {}
         );
 
-        if (typeof final_options.unique_depth !== "number") {
-            final_options.unique_depth = 0;
+        if (typeof options.unique_depth !== "number") {
+            options.unique_depth = 0;
         }
 
-        if (typeof final_options.type !== "object") {
-            final_options.type = {};
+        if (typeof options.type !== "object") {
+            options.type = {};
         }
 
-        for (let type in final_options.type) {
-            final_options.type[type] = Object.assign(
+        for (let type in options.type) {
+            options.type[type] = Object.assign(
                 {
                     unique: [],
                     check: [],
                     field: {}
                 },
-                final_options.type[type]
+                options.type[type]
             );
 
-            if (!Array.isArray(final_options.type[type].unique)) {
-                final_options.type[type].unique = [];
+            if (!Array.isArray(options.type[type].unique)) {
+                options.type[type].unique = [];
             }
 
-            if (!Array.isArray(final_options.type[type].check)) {
-                final_options.type[type].check = [];
+            if (!Array.isArray(options.type[type].check)) {
+                options.type[type].check = [];
             }
 
-            if (typeof final_options.type[type].field !== "object") {
-                final_options.type[type].field = {};
+            if (typeof options.type[type].field !== "object") {
+                options.type[type].field = {};
             }
 
-            for (let field in final_options.type[type].field) {
-                final_options.type[type].field[field] = Object.assign(
+            for (let field in options.type[type].field) {
+                options.type[type].field[field] = Object.assign(
                     {
                         not_null: false,
                         unique: false,
                         check: [],
                         default: false
                     },
-                    final_options.type[type].field[field]
+                    options.type[type].field[field]
                 );
 
-                if (!Array.isArray(final_options.type[type].field[field].check)) {
-                    final_options.type[type].field[field].check = [];
+                if (!Array.isArray(options.type[type].field[field].check)) {
+                    options.type[type].field[field].check = [];
                 }
             }
         }
 
-        return final_options;
+        return options;
     }
 
-    buildMaps(in_options: Partial<MDDatabaseOptions> = {}) {
+    buildMaps(in_options: number | Partial<MDDatabaseOptions> = {}) {
         let flat = flatten(this.data);
         let type_to_table: Generic.Object<{
             columns: {
@@ -550,7 +559,7 @@ export class MDDatabase {
     /* #endregion */
 
     /* #region To Functions */
-    async toFile(location: string, options: Partial<MDDatabaseOptions> = {}) {
+    async toFile(location: string, in_options: number | Partial<MDDatabaseOptions> = {}) {
         let type = (location.split(".").pop() || "").toLowerCase();
         let content;
 
@@ -564,7 +573,7 @@ export class MDDatabase {
                 break;
 
             case "sql":
-                content = this.toSQL(options);
+                content = this.toSQL(in_options);
                 break;
 
             case "ts":
@@ -592,7 +601,7 @@ export class MDDatabase {
         return this.md;
     }
 
-    toSQL(in_options: Partial<MDDatabaseOptions> = {}) {
+    toSQL(in_options: number | Partial<MDDatabaseOptions> = {}) {
         let options = this.getOptions(in_options);
         let { flat, type_to_table, name_to_record } = this.buildMaps(in_options);
 

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -13,6 +13,7 @@ interface MDType {
 
 interface MDDatabaseOptions {
     unique_depth: number;
+    table: Generic.Object<{}>;
 }
 
 namespace is {
@@ -273,12 +274,21 @@ export class MDDatabase {
 
     /* #region Management Functions */
     getOptions(options: Partial<MDDatabaseOptions> = {}): MDDatabaseOptions {
-        return Object.assign(
+        let final_options = Object.assign(
             {
-                unique_depth: 0
+                unique_depth: 0,
+                table: {}
             },
             options || {}
         );
+
+        if ("table" in options) {
+            for (let table in options.table) {
+                final_options.table[table] = Object.assign({}, options.table[table]);
+            }
+        }
+
+        return final_options;
     }
 
     buildMaps(in_options: Partial<MDDatabaseOptions> = {}) {


### PR DESCRIPTION
# Changes

Implemented MDDatabaseOptions interface as:

```ts
interface MDDatabaseOptions {
    unique_depth: number;
    type: Generic.Object<{
        check: string[];
        unique: {
            fields: string[];
            conflict: MDDatabaseConflict;
        }[];

        field: Generic.Object<{
            not_null: false | MDDatabaseConflict;
            check: string[];
            unique: false | MDDatabaseConflict;
            default: false | string;
        }>;
    }>;
}
```

Using MDDatabaseConflict as:

```ts
export enum MDDatabaseConflict {
    ROLLBACK,
    ABORT,
    FAIL,
    IGNORE,
    REPLACE
}
```

Methods that took `unique_depth` now support either a number (to be used for `unique_depth`) or `MDDatabaseOptions`

---

# Usage

Per the issue described in #9 I've updated the methods to accept an object that can be made more flexible over time as further options or customisation is needed, at the moment most of the implemented options revolve around constraints.

I don't believe that configurations for INSERT statements are required at the moment, as the top-level table constraints should allow for enough flexibility, though again this could easily be expanded in the future if required as the objects aren't fixed.

Lovely SQL syntax graph from [SQLite CREATE TABLE documentation](https://www.sqlite.org/lang_createtable.html)

![image](https://user-images.githubusercontent.com/32066836/132141541-9424df96-afcb-4bba-8f41-dbe38ae93cfc.png)

In the above diagram both the `table-constraint` and `column-constraint` portions have been (mostly) implemented.