### PR TITLE
Implement unnamed records, fixed higher parents

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -257,10 +257,8 @@ export class MDDatabase {
                 if (current.depth === 1 || feed.length === 0) {
                     feed.push(current);
                 } else if (current.parent) {
-                    if (current.depth === current.parent.depth) {
+                    while (current.parent && current.parent.parent && current.depth <= current.parent.depth) {
                         current.parent = current.parent.parent;
-                    } else if (current.depth < current.parent.depth && current.parent.parent) {
-                        current.parent = current.parent.parent.parent;
                     }
 
                     if (

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -239,7 +239,7 @@ export class MDDatabase {
         lines.forEach(line => {
             line = line.trim();
 
-            let depth = line.match(/^(?<depth>#{1,}\s)(?<name>.+?)($|\((?<type>.+?)\))/);
+            let depth = line.match(/^(?<depth>#{1,}\s)(?<name>.*?)($|\((?<type>.+?)\))/);
             if (depth && depth.groups) {
                 if (!depth.groups.type) {
                     throw new Error(`Unknown type for "${depth.groups.name.trim()}"`);
@@ -247,7 +247,7 @@ export class MDDatabase {
 
                 current = {
                     depth: depth.groups.depth.length - 1,
-                    name: depth.groups.name.trim().toLowerCase(),
+                    name: depth.groups.name.trim().toLowerCase() || randomUUID(),
                     type: depth.groups.type.trim().toLowerCase(),
                     children: [],
                     properties: {},


### PR DESCRIPTION
Closes #26 which allows for the usage of unnamed records within the MD dataset,

Formatted the same as a regular heading, but without any name (`#### (type)`).

These are given unique (using `randomUUID`) names, preventing references, but removing conflicts.

---

Furthermore, during testing I noticed that when heading depths were more than one, they broke.

The following as an example, this was fine:

```
# h1 (t)

## h2 (t)

### h3 (t)

## h4 (t)

# h5 (t)
```

Whereas this was not:

```
# h1 (t)

## h2 (t)

### h3 (t)

# h4  (t)
```